### PR TITLE
Update installation instructions to include all auto-configured shells

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -12,11 +12,7 @@ On most Unix systems, you can install Volta with a single command:
 curl -sSLf https://get.volta.sh | bash
 ```
 
-For [bash](https://www.gnu.org/software/bash/), this installer will automatically update your console startup script.
-
-{% include warn.html content="The installation script is currently tailored to bash. A more universal installer is in development, but Volta should work in all shells." %}
-
-To configure other shells to use Volta, edit your console startup scripts to:
+For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and [fish](http://fishshell.com/), this installer will automatically update your console startup script. To configure other shells to use Volta, edit your console startup scripts to:
 - Set the `VOLTA_HOME` variable to `~/.volta`
 - Add `$VOLTA_HOME/bin` to the beginning of your `PATH` variable
 


### PR DESCRIPTION
Closes volta-cli/volta#462

Update the "Getting Started" page to correctly reflect all of the shells that we auto-configure, and remove the warning about the installer being bash-focused.