### PR TITLE
Updated commands to build and install Volta locally

### DIFF
--- a/subdomains/docs/_contributing/index.md
+++ b/subdomains/docs/_contributing/index.md
@@ -37,17 +37,13 @@ cargo build
 To install a locally built copy of Volta, you can use the helper scripts provided in the `dev` directory:
 
 ```sh
-cargo build
-./dev/unix/build.sh debug
-./dev/unix/install.sh
+./dev/unix/volta-install.sh --dev
 ```
 
-Or:
+Or to build and install release binaries:
 
 ```sh
-cargo build --release
-./dev/unix/build.sh
-./dev/unix/install.sh
+./dev/unix/volta-install.sh --release
 ```
 
 ### Formatting


### PR DESCRIPTION
The `volta-install.sh` script can build and install `dev` and `release` builds of Volta. This new workflow is only one command, and is closer to how users will install Volta now that `volta-install.sh` is served from http://get.volta.sh.