### PR TITLE
Remove curl flags from installer CTAs

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -9,7 +9,7 @@ title: Getting Started
 On most Unix systems, you can install Volta with a single command:
 
 ```bash
-curl -sSLf https://get.volta.sh | bash
+curl https://get.volta.sh | bash
 ```
 
 For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and [fish](http://fishshell.com/), this installer will automatically update your console startup script. To configure other shells to use Volta, edit your console startup scripts to:

--- a/subdomains/www/index.md
+++ b/subdomains/www/index.md
@@ -15,7 +15,7 @@ features:
 
 ```bash
 # install Volta
-curl -sSLf https://get.volta.sh | bash
+curl https://get.volta.sh | bash
 
 # install Node
 volta install node


### PR DESCRIPTION
Related to https://github.com/volta-cli/get/pull/3

Once we convert the `get.volta.sh` domain into a 200 proxy, we can remove the curl flags from our installation directions, as they won't be needed any more.

Note: I left the callouts in the blog posts alone, as I felt the blog posts should remain as-is, instead of trying to keep them up-to-date with the current recommended approach.