### PR TITLE
Add note about needing Developer Mode to Windows section

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -19,3 +19,5 @@ For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and
 ## Windows Installation
 
 For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-windows-x86_64.msi) and follow the instructions.
+
+{% include note.html content="Volta's functionality depends on creating symlinks, so you must have <a href=\"https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers\" target=\"_blank\" noreferrer noopener>Developer Mode</a> enabled or be running with elevated privileges (not recommended)" %}

--- a/theme/_includes/note.html
+++ b/theme/_includes/note.html
@@ -1,0 +1,4 @@
+<div class="alert alert-note" role="alert">
+  <p class="alert-title">NOTE</p>
+  <p>{{ include.content }}</p>
+</div>

--- a/theme/_includes/warn.html
+++ b/theme/_includes/warn.html
@@ -1,4 +1,4 @@
 <div class="alert alert-warn" role="alert">
-    <p class="alert-warn-title">WARNING</p>
+    <p class="alert-title">WARNING</p>
     <p>{{ include.content }}</p>
 </div>

--- a/theme/_sass/volta/_alerts.scss
+++ b/theme/_sass/volta/_alerts.scss
@@ -1,15 +1,34 @@
-.alert.alert-warn {
-    background-color: rgba(255,229,100,.3);
-    border-color: #e7c000;
-    color: #6b5900;
+.alert {
     padding: .1rem 1.5rem;
     border-left-width: .5rem;
     border-left-style: solid;
     margin: 1rem 0;
 
-    .alert-warn-title {
-        color: #b29400;
+    .alert-title {
         font-weight: 600;
         margin-bottom: -.4rem;
+    }
+
+    &.alert-warn {
+        color: #6b5900;
+        background-color: rgba(255,229,100,.3);
+        border-color: #e7c000;
+
+        .alert-title {
+            color: #b29400;
+        }
+    }
+
+    &.alert-note {
+        color: #0c5460;
+        background-color: #d1ecf1;
+        border-color: #2b97a9;
+        .alert-title {
+            font-weight: 600;
+        }
+
+        a {
+            font-weight: 600;
+        }
     }
 }


### PR DESCRIPTION
While debugging an issue on Discord, we discovered that `volta install <package>` only works on Windows if developer mode is on (or if you are running an administrative prompt), because the Windows API to create a symlink requires one of those two situations.

We don't currently have a good solution to make it work without Developer Mode, so adding a note to the "Getting Started" page that lets the user know developer mode is required to get full functionality from Volta.

Also restructured some of the theme CSS and added a `note.html` snippet that can be used to insert a note into a page (similar to a warning but colored teal instead of yellow and titled "NOTE" instead of "WARNING").