### PR TITLE
Add WSL section and clean up Windows requirement note

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -20,4 +20,12 @@ For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and
 
 For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-windows-x86_64.msi) and follow the instructions.
 
-{% include note.html content="Volta's functionality depends on creating symlinks, so you must have <a href=\"https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers\" target=\"_blank\" noreferrer noopener>Developer Mode</a> enabled or be running with elevated privileges (not recommended)" %}
+{% include note.html content="Volta's functionality depends on creating symlinks, so you must either:
+<ul>
+    <li>Enable <a href=\"https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development#accessing-settings-for-developers\" target=\"_blank\" noreferrer noopener>Developer Mode</a> (recommended)</li>
+    <li>Run Volta with elevated privileges (not recommended)</li>
+</ul>" %}
+
+### Windows Subsystem for Linux
+
+If you are using Volta within the Windows Subsystem for Linux, follow the Unix installation guide above.


### PR DESCRIPTION
Based on some feedback we have received about the Getting Started guide, clean up 2 things:

1. Add a "Windows Subsystem for Linux" section to make it explicit that WSL users should follow the Unix install guide.
2. Clean up the note about needing Developer Mode / Elevated Privileges to make it clear that we recommend Developer Mode and Elevated Privileges is not recommended.