### PR TITLE
Bump required Rust version to 1.34 in Contributing.

### DIFF
--- a/subdomains/docs/_contributing/index.md
+++ b/subdomains/docs/_contributing/index.md
@@ -22,7 +22,7 @@ Contribution to Volta is organized under the terms of the [Contributor Covenant 
 
 ### Rust
 
-Volta is intended to compile with [Rust 1.33](https://www.rust-lang.org/) or newer.
+Volta is intended to compile with [Rust 1.34](https://www.rust-lang.org/) or newer.
 
 ### Building
 


### PR DESCRIPTION
Per comments on volta-cli/volta#505, changes made while refactoring the resolve/fetch/install process require Rust v1.34.0+ to build.