### PR TITLE
Fix manual editing of console startup scripts

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -13,7 +13,7 @@ curl https://get.volta.sh | bash
 ```
 
 For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and [fish](http://fishshell.com/), this installer will automatically update your console startup script. To configure other shells to use Volta, edit your console startup scripts to:
-- Set the `VOLTA_HOME` variable to `~/.volta`
+- Set the `VOLTA_HOME` variable to `$HOME/.volta`
 - Add `$VOLTA_HOME/bin` to the beginning of your `PATH` variable
 
 ## Windows Installation


### PR DESCRIPTION
Our "Getting Started" docs, under the section about how to manually edit the terminal startup scripts, were suggesting that users set `VOLTA_HOME` to `~/.volta`. However, if a user actually does that, it will subtly break Volta since we don't automatically expand `~` into the user's home directory.

This can lead to the creation of a bunch of directories named `~` everywhere the user runs `volta`, as well as breaking `yarn` scripts since the `PATH` isn't expanded there either.