### PR TITLE
Fix windows installer path

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -18,7 +18,7 @@ For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and
 
 ## Windows Installation
 
-For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-windows-x86_64.msi) and follow the instructions.
+For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-x86_64.msi) and follow the instructions.
 
 {% include note.html content="Volta's functionality depends on creating symlinks, so you must either:
 <ul>


### PR DESCRIPTION
The [Getting Started page](https://docs.volta.sh/guide/getting-started) points to a Windows installer that has a different name than previous releases.

Broken link: `https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-windows-x86_64.msi`

Working link: `https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-x86_64.msi`

This appears to have previously worked for the `v0.6.3` release... https://github.com/volta-cli/volta/releases/tag/v0.6.3