### PR TITLE
Add advanced section with more information about installing packages

### DIFF
--- a/subdomains/docs/_advanced/packages.md
+++ b/subdomains/docs/_advanced/packages.md
@@ -1,0 +1,26 @@
+---
+title: Package Binaries
+---
+
+# Package Binaries
+
+Details about the process of installing package binaries.
+
+## Customizing Download Locations
+
+Internally, `volta install <tool>` uses npm-style resolution to determine which versions are available and the download location for package binaries. Accordingly, to redirect and use an internal repository (i.e. to install an internal tool from a private repo), you can create a `.npmrc` file in your home directory. Options specified there will be honored when resolving and downloading a tool, as well as when resolving the dependencies of a given tool.
+
+## Pinned Node Version
+
+As described in [Understanding Volta](/guide/understanding#installing-package-binaries), Volta will pin a version of Node when a tool is installed, so that the tool can continue to be used, even if the default Node version changes. The process used to determine which version should be pinned is as follows:
+
+### Prior to Volta 0.6.8
+
+* If the package has `engines` specified in `package.json`, use the latest version of Node that meets the requirements in `engines`
+* Otherwise, use the most recent version of Node
+
+### Volta 0.6.8 and beyond
+
+* If the package has `engines` specified in `package.json`, use the latest LTS version of Node that meets the requirements
+* If no LTS versions meet the requirements then use the latest overall version that satisfies `engines`
+* If `engines` isn't available, use the most recent LTS version of Node

--- a/subdomains/docs/_data/sidebar.yml
+++ b/subdomains/docs/_data/sidebar.yml
@@ -59,6 +59,14 @@
           title: Hooks file format
         - id: hook-types
           title: Hook types
+    - id: packages
+      url: /advanced/packages
+      title: Package Binaries
+      sub-headers:
+        - id: customizing-download-locations
+          title: Customizing Download Locations
+        - id: pinned-node-version
+          title: Pinned Node Version
 - id: contributing
   url: /contributing/
   title: Contributing

--- a/subdomains/docs/_guide/understanding.md
+++ b/subdomains/docs/_guide/understanding.md
@@ -53,7 +53,7 @@ echo '# Hello world' > README.md
 vuepress dev
 ```
 
-When you install a package to your toolchain, Volta selects a Node engine for the tool based on the [`"engines"`](https://docs.npmjs.com/files/package.json#engines) field in that package's `package.json` manifest and _pins_ the tool to that engine. (If the package doesn't specify this field, Volta uses your current default Node engine instead.) Volta won't change the tool's pinned engine unless you update the tool, no matter what. This way, you can be confident that your installed tools don't change behind your back.
+When you install a package to your toolchain, Volta selects a Node engine for the tool based on the [`"engines"`](https://docs.npmjs.com/files/package.json#engines) field in that package's `package.json` manifest and _pins_ the tool to that engine (see [Package Binaries](/advanced/packages#pinned-node-version) for more information). Volta won't change the tool's pinned engine unless you update the tool, no matter what. This way, you can be confident that your installed tools don't change behind your back.
 
 ## Managing your project
 


### PR DESCRIPTION
Add some more Advanced docs about specifics of the package install process. Also update the "Understanding Volta" section about installing packages to link to that for more information.

Note: This shouldn't be merged until Volta 0.6.8 is released, as it references changes in that version which aren't available yet.