### PR TITLE
Add docs for 'volta setup'

### DIFF
--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -11,21 +11,7 @@ Details about how the installers work and how to create your own custom installe
 As of Volta 0.7.0, all of the official installers work in the same way:
 
 1. Unpack the Volta binaries
-2. Call `volta setup` with the `volta` binaries that was unpacked
-    * `volta setup` Modifies the user's PATH / Profile to ensure that the shim directory is accessible.
-
-### Unix Installer
-
-The unix installer will unpack all of the binaries into `~/.volta/bin`, so they are installed only for the specific user. `volta setup` will then search for profile scripts using the following list:
-
-* `~/.profile`
-* `~/.bash_profile`
-* `~/.bashrc`
-* `~/.zshrc`
-* `~/.config/fish/config.fish`
-* The value of the `PROFILE` environment variable
-
-For each of these files that exist, `volta setup` will modify it to include lines that define `VOLTA_HOME` and add `$VOLTA_HOME/bin` to the `PATH` environment variable.
+2. Call `volta setup` with the `volta` binary that was unpacked (see [volta setup](/reference/setup) for more information)
 
 ### Windows Installer
 
@@ -36,7 +22,31 @@ The Windows installer will unpack all of the binaries into `Program Files\Volta`
 * `npx`
 * `yarn`
 
-Finally, the installer will call `volta setup`, which will modify the User's `Path` environment variable to include the shim directory (`%LOCALAPPDATA%\Volta\bin`).
+### Unix Installer
+
+The unix installer will unpack all of the binaries into `~/.volta/bin`, so they are installed only for the specific user.
+
+## Skipping Volta Setup
+
+If you wish to run the installer but do not want your profile scripts modified by `volta setup`, you can pass the `--skip-setup` option to the installer:
+
+```bash
+curl https://get.volta.sh | bash -s -- --skip-setup
+```
+
+{% include note.html content="We don't currently support skipping <code>volta setup</code> on Windows" %}
+
+## Installing Old Versions
+
+The default installer script provided by [get.volta.sh](https://get.volta.sh) only supports installing Volta 0.7.0 and above. If you wish to install an older version, you can install it using the following script (on Unix, replacing `0.6.8` with the version you want to install):
+
+```
+curl https://raw.githubusercontent.com/volta-cli/volta/e0290c2d7b0e80bf64e7c5d403789bc51678d16c/dev/unix/volta-install.sh | bash -s -- --version 0.6.8
+```
+
+For Windows, you can download and install the Installer `.msi` file for the specific version that you want to install.
+
+{% include note.html content="Volta does not support downgrading, so in order to downgrade you will need to completely uninstall Volta and then install the lower version" %}
 
 ## Custom Installers
 
@@ -64,15 +74,3 @@ Updating the PATH can be managed manually, if desired, or you can call `volta se
 ### Custom Volta Home (Optional)
 
 If you wish to use a different directory for the Volta data than the default `VOLTA_HOME` listed in the previous section, you need to set the environment variable `VOLTA_HOME` to that directory. If that is set, then `volta setup` will still work correctly for a custom data directory.
-
-## Installing Old Versions
-
-The default installer script provided by [get.volta.sh](https://get.volta.sh) only supports installing Volta 0.7.0 and above. If you wish to install an older version, you can install it using the following script (on Unix, replacing `0.6.8` with the version you want to install):
-
-```
-curl https://raw.githubusercontent.com/volta-cli/volta/e0290c2d7b0e80bf64e7c5d403789bc51678d16c/dev/unix/volta-install.sh | bash -s -- --version 0.6.8
-```
-
-For Windows, you can download and install the Installer `.msi` file for the specific version that you want to install.
-
-{% include note.html content="Volta does not support downgrading, so in order to downgrade you will need to completely uninstall Volta and then install the lower version" %}

--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -34,7 +34,7 @@ If you wish to run the installer but do not want your profile scripts modified b
 curl https://get.volta.sh | bash -s -- --skip-setup
 ```
 
-{% include note.html content="We don't currently support skipping <code>volta setup</code> on Windows" %}
+{% include note.html content="We don't currently support skipping <code>volta setup</code> on Windows." %}
 
 ## Installing Old Versions
 
@@ -46,7 +46,7 @@ curl https://raw.githubusercontent.com/volta-cli/volta/e0290c2d7b0e80bf64e7c5d40
 
 For Windows, you can download and install the Installer `.msi` file for the specific version that you want to install.
 
-{% include note.html content="Volta does not support downgrading, so in order to downgrade you will need to completely uninstall Volta and then install the lower version" %}
+{% include note.html content="Volta does not support downgrading, so in order to downgrade you will need to completely uninstall Volta and then install the lower version." %}
 
 ## Custom Installers
 

--- a/subdomains/docs/_data/sidebar.yml
+++ b/subdomains/docs/_data/sidebar.yml
@@ -42,6 +42,9 @@
     - id: pin
       url: /reference/pin/
       title: volta pin
+    - id: setup
+      url: /reference/setup/
+      title: volta setup
     - id: help
       url: /reference/help/
       title: volta help
@@ -73,10 +76,12 @@
       sub-headers:
         - id: current-installers
           title: Current Installers
-        - id: custom-installers
-          title: Custom Installers
+        - id: skipping-volta-setup
+          title: Skipping Volta Setup
         - id: installing-old-versions
           title: Installing Old Versions
+        - id: custom-installers
+          title: Custom Installers
 - id: contributing
   url: /contributing/
   title: Contributing

--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -12,7 +12,7 @@ On most Unix systems, you can install Volta with a single command:
 curl https://get.volta.sh | bash
 ```
 
-For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and [fish](http://fishshell.com/), this installer will automatically update your console startup script. To configure other shells to use Volta, edit your console startup scripts to:
+For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and [fish](http://fishshell.com/), this installer will automatically update your console startup script. If you wish to prevent modifications to your console startup script, see [Skipping Volta Setup](/advanced/installers#skipping-volta-setup). To manually configure your shell to use Volta, edit your console startup scripts to:
 - Set the `VOLTA_HOME` variable to `$HOME/.volta`
 - Add `$VOLTA_HOME/bin` to the beginning of your `PATH` variable
 

--- a/subdomains/docs/_reference/fetch.md
+++ b/subdomains/docs/_reference/fetch.md
@@ -4,15 +4,19 @@ title: volta fetch
 
 # `volta fetch`
 
-The `volta fetch` command has the following synax:
+The `volta fetch` command will allow you to fetch a tool into the local cache, without setting it as a default or making it available, for future offline use. It has the following synax:
 
 ```
-Fetch a tool to the local machine
+Fetches a tool to the local machine
 
-Usage:
-    volta fetch <tool> <version>
-    volta fetch -h | --help
+USAGE:
+    volta fetch [FLAGS] <tool[@version]>...
 
-Options:
-    -h, --help     Display this message
+FLAGS:
+        --verbose    Enables verbose diagnostics
+        --quiet      Prevents unnecessary output
+    -h, --help       Prints help information
+
+ARGS:
+    <tool[@version]>...    Tools to fetch, like `node`, `yarn@latest` or `your-package@^14.4.3`.
 ```

--- a/subdomains/docs/_reference/help.md
+++ b/subdomains/docs/_reference/help.md
@@ -7,12 +7,11 @@ title: volta help
 The `volta help` command has the following synax:
 
 ```
-Get some help with a volta command
+Prints this message or the help of the given subcommand(s)
 
-Usage:
-    volta help [<command>]
-    volta help -h | --help
+USAGE:
+    volta help [subcommand]...
 
-Options:
-    -h, --help     Display this message
+ARGS:
+    <subcommand>...    The subcommand whose help message to display
 ```

--- a/subdomains/docs/_reference/index.md
+++ b/subdomains/docs/_reference/index.md
@@ -37,5 +37,6 @@ SUBCOMMANDS:
     list           Displays the current toolchain
     completions    Generates Volta completions
     which          Locates the actual binary that will be called by Volta
+    setup          Enables Volta for the current user / shell
     help           Prints this message or the help of the given subcommand(s)
 ```

--- a/subdomains/docs/_reference/install.md
+++ b/subdomains/docs/_reference/install.md
@@ -4,18 +4,19 @@ title: volta install
 
 # `volta install`
 
-The `volta install` command has the following synax:
+The `volta install` command will set your default version of a tool. It will also fetch that tool if it isn't already cached locally. It has the following synax:
 
 ```
-Install a tool in the user toolchain
+Installs a tool in your toolchain
 
-Usage:
-    volta install <tool>[@<version>]
-    volta install -h | --help
+USAGE:
+    volta install [FLAGS] <tool[@version]>...
 
-Options:
-    -h, --help     Display this message
+FLAGS:
+        --verbose    Enables verbose diagnostics
+        --quiet      Prevents unnecessary output
+    -h, --help       Prints help information
 
-Supported Tools:
-    Currently Volta supports installing `node` and `yarn` - support for more tools is coming soon!
+ARGS:
+    <tool[@version]>...    Tools to install, like `node`, `yarn@latest` or `your-package@^14.4.3`.
 ```

--- a/subdomains/docs/_reference/pin.md
+++ b/subdomains/docs/_reference/pin.md
@@ -4,15 +4,23 @@ title: volta pin
 
 # `volta pin`
 
-The `volta pin` command has the following synax:
+The `volta pin` command will update a project's `package.json` file to use the selected version of a tool.
+
+{% include note.html content="<code>volta pin</code> only works with Node & Yarn. For dependencies, you should use <code>npm install</code> or <code>yarn add</code> to update the selected versions." %}
+
+The command has the following syntax:
 
 ```
-Select a tool for the current project's toolchain
+Pins your project's runtime or package manager
 
-Usage:
-    volta pin <tool>[@<version>]
-    volta pin -h | --help
+USAGE:
+    volta pin [FLAGS] <tool[@version]>...
 
-Options:
-    -h, --help     Display this message
+FLAGS:
+        --verbose    Enables verbose diagnostics
+        --quiet      Prevents unnecessary output
+    -h, --help       Prints help information
+
+ARGS:
+    <tool[@version]>...    Tools to pin, like `node@lts` or `yarn@^1.14`.
 ```

--- a/subdomains/docs/_reference/setup.md
+++ b/subdomains/docs/_reference/setup.md
@@ -1,0 +1,41 @@
+---
+title: volta setup
+---
+
+# `volta setup`
+
+The `volta setup` command will enable Volta by modifying the `PATH` for the current user (in a platform-dependent way) to include the Volta shim directory.
+
+## Unix
+
+On Unix, `volta setup` will search for profile scripts using the following list:
+
+* `~/.profile`
+* `~/.bash_profile`
+* `~/.bashrc`
+* `~/.zshrc`
+* `~/.config/fish/config.fish`
+* The value of the `PROFILE` environment variable
+
+For each of these files that exist, `volta setup` will modify it to include lines that define `VOLTA_HOME` and add `$VOLTA_HOME/bin` to the `PATH` environment variable.
+
+## Windows
+
+On Windows, `volta setup` will modify the User `Path` environment variable to include the shim directory (`%LOCALAPPDATA%\Volta\bin`).
+
+## Syntax
+
+The command has the following syntax:
+
+```
+Enables Volta for the current user
+
+USAGE:
+    volta setup [FLAGS]
+
+FLAGS:
+        --verbose    Enables verbose diagnostics
+        --quiet      Prevents unnecessary output
+    -h, --help       Prints help information
+```
+


### PR DESCRIPTION
* Added "Reference" page for `volta setup`, with information about how it modifies the user's machine to support Volta
* Updated other "Reference" pages to show the current output of `volta help <command>` (several were outdated).
* Reworked the "Installers" Advanced page to link to the `volta setup` reference page.
* Added a note about how to run the installer without `volta setup`
* Added a link to the above note to the "Getting Started" page, so it's more discoverable for users that want that behavior.