### PR TITLE
Tweaks to footer

### DIFF
--- a/theme/_includes/footer.html
+++ b/theme/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="site-footer">
     <div class="footer-contents">
         <div class="community-container">
-            <div>Built with <span class="colorful-heart">♥</span> by <a class="contributors" href="https://github.com/volta-cli/volta/graphs/contributors">The Volta Contributors</a> ⚡</div>
+            <div>Built with <span class="colorful-heart">♥</span> by <a class="contributors" href="https://github.com/volta-cli/volta/graphs/contributors">the Volta community</a> ⚡</div>
             <div class="social">
                 <a href="https://twitter.com/usevolta"><img src="/assets/twitter.svg"/></a>
                 <a href="https://discord.gg/hgPTz9A"><img src="/assets/discord.svg"/></a>

--- a/theme/_sass/volta/_layout.scss
+++ b/theme/_sass/volta/_layout.scss
@@ -453,12 +453,15 @@ footer {
 
 @media (max-width: $media-mobile) {
   footer {
+    padding-left: 2rem;
+    padding-right: 2rem;
+
     .footer-contents {
       margin: 0;
       flex-direction: column;
 
       .community-container {
-        margin-bottom: 1rem;
+        margin-bottom: 3rem;
       }
 
       .community-container, .sponsor-container {


### PR DESCRIPTION
- rename "The Volta Contributors" to "the Volta community" -- feels more warm and inclusive, defines Volta more as a community than as a recipient of donations
- narrow the horizontal padding on mobile to avoid the :zap: spilling over
- widen the vertical gap between footer sections (it was crowding)

[Preview](https://5e63f73ba05d370008074912--pensive-ardinghelli-58fa3b.netlify.com)

![Preview screenshot](https://user-images.githubusercontent.com/307871/76151354-f286b080-6068-11ea-964b-e9d5a2faef5f.jpg)