### PR TITLE
Add support for seo tags

### DIFF
--- a/subdomains/blog/Gemfile
+++ b/subdomains/blog/Gemfile
@@ -19,6 +19,7 @@ gem "volta-jekyll-theme", :path => "../../theme"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-seo-tag", :git => "https://github.com/jekyll/jekyll-seo-tag.git", :ref => "38ef0be"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/subdomains/blog/Gemfile.lock
+++ b/subdomains/blog/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/jekyll/jekyll-seo-tag.git
+  revision: 38ef0bea229de85f25b5735c432587c09b494398
+  ref: 38ef0be
+  specs:
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
+
 PATH
   remote: ../../theme
   specs:
@@ -67,6 +75,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.3)
   jekyll-feed (~> 0.6)
+  jekyll-seo-tag!
   tzinfo-data
   volta-jekyll-theme!
 

--- a/subdomains/blog/_config.yml
+++ b/subdomains/blog/_config.yml
@@ -13,23 +13,72 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Blog | Volta
 email: david.herman@gmail.com
-description: >- # this means to ignore newlines until "baseurl:"
-  The Volta blog.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
 permalink: /:year/:month/:day/:title/
 excerpt_separator: <!--more-->
 subdomain: blog
+
+# Social sharing settings
+# These are the settings used by jekyll-seo-tag to construct open graph,
+# twitter summary card and JSON-LD site and post metadata
+# Docs: https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
+##########################################################################
+# Your site's title (e.g., Ben's awesome site, The GitHub Blog, etc.), 
+# used as part of the title tag like 'page.title | title'.
+title: Volta
+# A short description (e.g., A blog dedicated to reviewing cat gifs), 
+# used as part of the title tag of the home page like 'title | tagline'.
+tagline: Blog
+# A longer description used for the description meta tag. 
+# Also used as fallback for pages that don't provide their own description and 
+# as part of the home page title tag if tagline is not defined.
+description: The Volta blog.
+# The full URL to your site. Note: site.github.url will be used by default.
+# the base hostname & protocol for your site, e.g. http://example.com
+url: https://blog.volta.sh
+# Global author information
+authors: ~
+# The following properties are available:
+#   twitter:card - The site's default card type
+#   twitter:username - The site's Twitter handle. 
+twitter:
+  username: usevolta
+  card: summary
+# The following properties are available:
+#   facebook:app_id - a Facebook app ID for Facebook insights
+#   facebook:publisher - a Facebook page URL or ID of the publishing entity
+#   facebook:admins - a Facebook user ID for domain insights linked to a personal account
+facebook:
+  app_id: ~
+  publisher: ~
+  admins: ~
+# URL to a site-wide logo (e.g., /assets/your-company-logo.png)
+logo: https://volta.sh/assets/wordmark.jpg
+# For specifying social profiles. The following properties are available:
+#   name - If the user or organization name differs from the site's name
+#   links - An array of links to social media profiles.
+social:
+  links:
+    - https://twitter.com/usevolta
+    - https://discord.gg/hgPTz9A
+    - https://github.com/volta-cli/volta
+# Verify ownership with several services at once using the following format:
+webmaster_verifications:
+  google: ~
+  bing: ~
+  alexa: ~
+  yandex: ~
+  baidu: ~
+# The locale these tags are marked up in. Of the format language_TERRITORY.
+lang: en_US
 
 # Build settings
 markdown: kramdown
 theme: volta-jekyll-theme
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/subdomains/blog/_posts/2018-08-20-state-of-the-notion.md
+++ b/subdomains/blog/_posts/2018-08-20-state-of-the-notion.md
@@ -3,7 +3,9 @@ layout: post
 title:  "State of the Notion"
 date:   2018-08-20 10:32:05 -0700
 categories: update
-author: Dave Herman
+author: 
+    name: Dave Herman
+    twitter: littlecalculist
 ---
 _Notion is a **JavaScript toolchain manager**, making sure you always get the right version of Node, package managers like npm and Yarn, and JS command-line tools. Best of all, Notion makes tool requirements **declarative and reproducible** by using_ `package.json` _to remember and launch the right versions of a project’s required tools, so developers and users always see their projects build and run in a consistent environment._
 

--- a/subdomains/blog/_posts/2019-02-05-state-of-the-notion.md
+++ b/subdomains/blog/_posts/2019-02-05-state-of-the-notion.md
@@ -3,7 +3,9 @@ layout: post
 title:  "State of the Notion"
 date:   2019-02-05 10:07:41 -0700
 categories: update
-author: Dave Herman
+author:
+    name: Dave Herman
+    twitter: littlecalculist
 ---
 _Notion is a **JavaScript toolchain manager**, making sure you always get the right version of Node, package managers like npm and Yarn, and JS command-line tools. Best of all, Notion makes tool requirements **declarative and reproducible** by using_ `package.json` _to remember and launch the right versions of a project’s required tools, so developers and users always see their projects build and run in a consistent environment._
 

--- a/subdomains/blog/_posts/2019-05-13-hello-volta.md
+++ b/subdomains/blog/_posts/2019-05-13-hello-volta.md
@@ -3,7 +3,9 @@ layout: post
 title:  "Hello Volta!"
 date:   2019-05-13 10:07:41 -0700
 categories: update
-author: Chuck Pierce and Dave Herman
+author: 
+    name: Chuck Pierce and Dave Herman
+    twitter: ChuckAPierce
 ---
 
 We’ve got a new version available… and a new name!

--- a/subdomains/blog/_posts/2019-06-18-global-installs-done-right.md
+++ b/subdomains/blog/_posts/2019-06-18-global-installs-done-right.md
@@ -3,7 +3,9 @@ layout: post
 title:  "Global installs done right"
 date:   2019-06-18 08:00:00 -0700
 categories: update
-author: Chuck Pierce and Dave Herman
+author: 
+    name: Chuck Pierce and Dave Herman
+    twitter: ChuckAPierce
 excerpt_separator: <!--more-->
 ---
 

--- a/subdomains/blog/_posts/2020-03-30-every-error-help-screen.md
+++ b/subdomains/blog/_posts/2020-03-30-every-error-help-screen.md
@@ -3,7 +3,9 @@ layout: post
 title:  "Every Error is a Help Screen in Disguise"
 date:   2020-03-30 08:00:00 -0700
 categories: [errors, delight]
-author: Chuck Pierce
+author: 
+    name: Chuck Pierce
+    twitter: ChuckAPierce
 excerpt_separator: <!--more-->
 ---
 

--- a/subdomains/blog/index.md
+++ b/subdomains/blog/index.md
@@ -12,7 +12,7 @@ layout: blog
 <h1 class="blog-excerpt-title"><a href="{{ post.url }}">{{ post.title }}</a></h1>
 
 <div class="blog-excerpt-date">
-    {{ post.date | date: "%B %-d, %Y" }} &bullet; {{ post.author }}
+    {{ post.date | date: "%B %-d, %Y" }} &bullet; {{ post.author.name }}
 </div>
 
 <div class="blog-excerpt">

--- a/subdomains/docs/Gemfile
+++ b/subdomains/docs/Gemfile
@@ -19,6 +19,7 @@ gem "volta-jekyll-theme", :path => "../../theme"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-seo-tag", :git => "https://github.com/jekyll/jekyll-seo-tag.git", :ref => "38ef0be"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/subdomains/docs/Gemfile.lock
+++ b/subdomains/docs/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/jekyll/jekyll-seo-tag.git
+  revision: 38ef0bea229de85f25b5735c432587c09b494398
+  ref: 38ef0be
+  specs:
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
+
 PATH
   remote: ../../theme
   specs:
@@ -70,6 +78,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)
+  jekyll-seo-tag!
   nokogiri (~> 1.10)
   tzinfo-data
   volta-jekyll-theme!

--- a/subdomains/docs/_config.yml
+++ b/subdomains/docs/_config.yml
@@ -13,14 +13,8 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Documentation | Volta
 email: david.herman@gmail.com
-description: >- # this means to ignore newlines until "baseurl:"
-  The Volta guide.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
 subdomain: docs
 
 collections:
@@ -43,11 +37,66 @@ defaults:
     values:
       layout: doc
 
+# Social sharing settings
+# These are the settings used by jekyll-seo-tag to construct open graph,
+# twitter summary card and JSON-LD site and post metadata
+# Docs: https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
+##########################################################################
+# Your site's title (e.g., Ben's awesome site, The GitHub Blog, etc.), 
+# used as part of the title tag like 'page.title | title'.
+title: Volta
+# A short description (e.g., A blog dedicated to reviewing cat gifs), 
+# used as part of the title tag of the home page like 'title | tagline'.
+tagline: Documentation
+# A longer description used for the description meta tag. 
+# Also used as fallback for pages that don't provide their own description and 
+# as part of the home page title tag if tagline is not defined.
+description: The Volta guide.
+# The full URL to your site. Note: site.github.url will be used by default.
+# the base hostname & protocol for your site, e.g. http://example.com
+url: https://docs.volta.sh
+# Global author information
+author: ~
+# The following properties are available:
+#   twitter:card - The site's default card type
+#   twitter:username - The site's Twitter handle. 
+twitter:
+  username: usevolta
+  card: summary
+# The following properties are available:
+#   facebook:app_id - a Facebook app ID for Facebook insights
+#   facebook:publisher - a Facebook page URL or ID of the publishing entity
+#   facebook:admins - a Facebook user ID for domain insights linked to a personal account
+facebook:
+  app_id: ~
+  publisher: ~
+  admins: ~
+# URL to a site-wide logo (e.g., /assets/your-company-logo.png)
+logo: https://volta.sh/assets/wordmark.jpg
+# For specifying social profiles. The following properties are available:
+#   name - If the user or organization name differs from the site's name
+#   links - An array of links to social media profiles.
+social:
+  links:
+    - https://twitter.com/usevolta
+    - https://discord.gg/hgPTz9A
+    - https://github.com/volta-cli/volta
+# Verify ownership with several services at once using the following format:
+webmaster_verifications:
+  google: ~
+  bing: ~
+  alexa: ~
+  yandex: ~
+  baidu: ~
+# The locale these tags are marked up in. Of the format language_TERRITORY.
+lang: en_US
+
 # Build settings
 markdown: kramdown
 theme: volta-jekyll-theme
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/subdomains/www/Gemfile
+++ b/subdomains/www/Gemfile
@@ -19,6 +19,7 @@ gem "volta-jekyll-theme", :path => "../../theme"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-seo-tag", :git => "https://github.com/jekyll/jekyll-seo-tag.git", :ref => "38ef0be"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/subdomains/www/Gemfile.lock
+++ b/subdomains/www/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/jekyll/jekyll-seo-tag.git
+  revision: 38ef0bea229de85f25b5735c432587c09b494398
+  ref: 38ef0be
+  specs:
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
+
 PATH
   remote: ../../theme
   specs:
@@ -67,6 +75,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)
+  jekyll-seo-tag!
   tzinfo-data
   volta-jekyll-theme!
 

--- a/subdomains/www/_config.yml
+++ b/subdomains/www/_config.yml
@@ -13,21 +13,70 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Volta - Start your engines.
 email: david.herman@gmail.com
-description: >- # this means to ignore newlines until "baseurl:"
-  Volta: Start your engines.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
 subdomain: www
+
+# Social sharing settings
+# These are the settings used by jekyll-seo-tag to construct open graph,
+# twitter summary card and JSON-LD site and post metadata
+# Docs: https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
+##########################################################################
+# Your site's title (e.g., Ben's awesome site, The GitHub Blog, etc.) 
+# used as part of the title tag like 'page.title | title'.
+title: Volta
+# A short description (e.g., A blog dedicated to reviewing cat gifs), 
+# used as part of the title tag of the home page like 'title | tagline'.
+tagline: Start your engines.
+# A longer description used for the description meta tag. 
+# Also used as fallback for pages that don't provide their own description and 
+# as part of the home page title tag if tagline is not defined.
+description: "Volta: Start your engines."
+# The full URL to your site. Note: site.github.url will be used by default.
+# the base hostname & protocol for your site, e.g. http://example.com
+url: https://volta.sh
+# Global author information
+author: ~
+# The following properties are available:
+#   twitter:card - The site's default card type
+#   twitter:username - The site's Twitter handle. 
+twitter:
+  username: usevolta
+  card: summary
+# The following properties are available:
+#   facebook:app_id - a Facebook app ID for Facebook insights
+#   facebook:publisher - a Facebook page URL or ID of the publishing entity
+#   facebook:admins - a Facebook user ID for domain insights linked to a personal account
+facebook:
+  app_id: ~
+  publisher: ~
+  admins: ~
+# URL to a site-wide logo (e.g., /assets/your-company-logo.png)
+logo: https://volta.sh/assets/wordmark.jpg
+# For specifying social profiles. The following properties are available:
+#   name - If the user or organization name differs from the site's name
+#   links - An array of links to social media profiles.
+social:
+  links:
+    - https://twitter.com/usevolta
+    - https://discord.gg/hgPTz9A
+    - https://github.com/volta-cli/volta
+# Verify ownership with several services at once using the following format:
+webmaster_verifications:
+  google: ~
+  bing: ~
+  alexa: ~
+  yandex: ~
+  baidu: ~
+# The locale these tags are marked up in. Of the format language_TERRITORY.
+lang: en_US
 
 # Build settings
 markdown: kramdown
 theme: volta-jekyll-theme
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/theme/_includes/head.html
+++ b/theme/_includes/head.html
@@ -3,12 +3,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   
-    {% if site.subdomain == "www" %}
-    <title>Volta - {{ page.tagline | escape }}</title>
-    {% else %}
-    <title>{% if page.title %}{{ page.title | escape }} | Volta{% else %}{{ site.title | escape }}{% endif %}</title>
-    {% endif %}
-    <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+    {% seo %}
   
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400|Montserrat:500,700|Ubuntu+Mono" rel="stylesheet">
     <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
@@ -34,5 +29,4 @@
         });
       });
     </script>
-  </head>
-  
+</head>  

--- a/theme/_layouts/post.html
+++ b/theme/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
     <div class="page-contents">
         <h1 class="blog-title">The Volta Blog</h1>
         <h1 class="post-title">{{ page.title }}</h1>
-        <div class="post-date">{{ page.date | date: "%B %-d, %Y" }} &bullet; {{ page.author }}</div>
+        <div class="post-date">{{ page.date | date: "%B %-d, %Y" }} &bullet; {{ page.author.name }}</div>
         <div class="post-contents">
             {{ content }}
         </div>


### PR DESCRIPTION
# Goal
Add support for various social tags, e.g. open graph, twitter card, JSON-LD, etc... so Volta website pages unfurl nicely when shared on social media like LinkedIn, Twitter, Slack, etc...

- Add `jekyll-seo-tag` plugin
  - Figured a configurable plugin was favorable to liquid spaghetti code
  - Specified a specific commit as a required feature, support for `tagline` is not yet released
- Add configuration for seo tags
 - Did not recreate the previous `title` and `description` _exactly_, but did try to stick to the spirit of how they were defined
- Add `seo` liquid tag to header and remove duplicate elements
- Update blog author to play nice with seo tags
- Update templates to play nice with blog author updates