### PR TITLE
Include sidebar.html within blog post

### DIFF
--- a/theme/_layouts/post.html
+++ b/theme/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% include sidebar.html class="blog" %}
+{% include sidebar.html class="post" %}
 <main class="page-container blog" aria-label="Content">
     <div class="page-contents">
         <h1 class="blog-title">The Volta Blog</h1>

--- a/theme/_layouts/post.html
+++ b/theme/_layouts/post.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 
+{% include sidebar.html class="blog" %}
 <main class="page-container blog" aria-label="Content">
     <div class="page-contents">
         <h1 class="blog-title">The Volta Blog</h1>

--- a/theme/_layouts/post.html
+++ b/theme/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% include sidebar.html class="post" %}
+{% include sidebar.html class="blog" %}
 <main class="page-container blog" aria-label="Content">
     <div class="page-contents">
         <h1 class="blog-title">The Volta Blog</h1>


### PR DESCRIPTION
I saw a post about Volta today (https://blog.volta.sh/2020/07/23/declare-your-tools/) on my phone and tried to click the hamburger menu in order to read more about the project, and noticed it is broken. This is easily reproducible using browser dev tools: the menu does not work within a specific blog post, but does within the directory of blog posts (https://blog.volta.sh/). It looks like it's because there is no `nav.sidebar` from within a given blog post. 

This PR adds the sidebar to a blog post to fix this behavior. 🙂 

Blog listing (with functionality):

<img width="911" alt="Screen Shot 2020-07-27 at 1 07 01 PM" src="https://user-images.githubusercontent.com/13544620/88575925-3d9a6380-d00a-11ea-83b7-fa86be1b85d7.png">

<img width="920" alt="Screen Shot 2020-07-27 at 1 07 11 PM" src="https://user-images.githubusercontent.com/13544620/88575932-412dea80-d00a-11ea-98eb-f86cad78994e.png">

Blog post (no `nav.sidebar`, so functionality does not work):
<img width="911" alt="Screen Shot 2020-07-27 at 1 07 22 PM" src="https://user-images.githubusercontent.com/13544620/88575886-2d828400-d00a-11ea-8af6-f61bb5c0cddb.png">


