### PR TITLE
Add Advanced section about Uninstalling Volta

### DIFF
--- a/subdomains/docs/_advanced/uninstall.md
+++ b/subdomains/docs/_advanced/uninstall.md
@@ -1,0 +1,30 @@
+---
+title: Uninstalling Volta
+---
+
+# Uninstalling Volta
+
+If Volta isn't meeting your needs and you'd like to uninstall it, we're sorry to see you go! We would greatly appreciate any feedback you may have about what was missing from your experience so that we can improve Volta in the future. We can be reached on [Twitter](https://twitter.com/usevolta), [Discord](https://discord.gg/hgPTz9A), or [GitHub](https://github.com/volta-cli/volta).
+
+## Unix Uninstallation
+
+There are two steps needed to completely uninstall Volta on Unix systems:
+
+- Remove the entire `~/.volta` directory
+
+```sh
+rm -rf ~/.volta
+```
+
+- Edit your shell profile scripts to remove the two lines that mention Volta. The profile scripts Volta locates by default are:
+    1. `.bashrc`
+    2. `.bash_profile`
+    3. `.zshrc`
+    4. `config.fish`
+    5. `.profile`
+
+{% include note.html content="You may need to open a new terminal after making this change, as many shells cache the location of recent commands" %}
+
+## Windows Uninstallation
+
+On Windows, Volta can be uninstalled by selecting it in the list at [Start > Settings > Apps](ms-settings:appsfeatures) and choosing _Uninstall_.

--- a/subdomains/docs/_data/sidebar.yml
+++ b/subdomains/docs/_data/sidebar.yml
@@ -67,6 +67,9 @@
     - id: workspaces
       url: /advanced/workspaces
       title: Workspaces
+    - id: uninstall
+      url: /advanced/uninstall
+      title: Uninstalling Volta
 - id: contributing
   url: /contributing/
   title: Contributing


### PR DESCRIPTION
We've had an outstanding issue for a while to document the steps needed to uninstall Volta (https://github.com/volta-cli/volta/issues/531). Adding a section under `Advanced` as, at least on Unix, it's a little bit involved.