### PR TITLE
Update reference section with all commands

### DIFF
--- a/subdomains/docs/_data/sidebar.yml
+++ b/subdomains/docs/_data/sidebar.yml
@@ -39,18 +39,21 @@
     - id: uninstall
       url: /reference/uninstall/
       title: volta uninstall
-    - id: list
-      url: /reference/list/
-      title: volta list
     - id: pin
       url: /reference/pin/
       title: volta pin
-    - id: run
-      url: /reference/run/
-      title: volta run
+    - id: list
+      url: /reference/list/
+      title: volta list
+    - id: which
+      url: /reference/which/
+      title: volta which
     - id: setup
       url: /reference/setup/
       title: volta setup
+    - id: run
+      url: /reference/run/
+      title: volta run
     - id: help
       url: /reference/help/
       title: volta help

--- a/subdomains/docs/_data/sidebar.yml
+++ b/subdomains/docs/_data/sidebar.yml
@@ -45,6 +45,9 @@
     - id: list
       url: /reference/list/
       title: volta list
+    - id: completions
+      url: /reference/completions/
+      title: volta completions
     - id: which
       url: /reference/which/
       title: volta which

--- a/subdomains/docs/_data/sidebar.yml
+++ b/subdomains/docs/_data/sidebar.yml
@@ -36,6 +36,9 @@
     - id: install
       url: /reference/install/
       title: volta install
+    - id: uninstall
+      url: /reference/uninstall/
+      title: volta uninstall
     - id: list
       url: /reference/list/
       title: volta list

--- a/subdomains/docs/_reference/completions.md
+++ b/subdomains/docs/_reference/completions.md
@@ -1,0 +1,46 @@
+---
+title: volta completions
+---
+
+# `volta completions`
+
+The `volta completions` command will generate command completion information for your shell. It has the following synax:
+
+```
+Generates Volta completions
+
+By default, completions will be generated for the value of your current shell,
+shell, i.e. the value of `SHELL`. If you set the `<shell>` option, completions
+will be generated for that shell instead.
+
+If you specify a directory, the completions will be written to a file there;
+otherwise, they will be written to `stdout`.
+
+
+USAGE:
+    volta completions [FLAGS] [OPTIONS] <shell>
+
+FLAGS:
+    -f, --force
+            Write over an existing file, if any.
+
+        --verbose
+            Enables verbose diagnostics
+
+        --quiet
+            Prevents unnecessary output
+
+    -h, --help
+            Prints help information
+
+
+OPTIONS:
+    -o, --output <out_file>
+            File to write generated completions to
+
+
+ARGS:
+    <shell>
+            Shell to generate completions for [possible values: zsh, bash, fish, powershell,
+            elvish]
+```

--- a/subdomains/docs/_reference/uninstall.md
+++ b/subdomains/docs/_reference/uninstall.md
@@ -1,0 +1,26 @@
+---
+title: volta uninstall
+---
+
+# `volta uninstall`
+
+The `volta uninstall` command allows you to remove any global package that has been installed with `volta install`.
+
+{% include note.html content="As of Volta 0.9.0, you can also uninstall a package using your package manager with <code>npm uninstall --global</code> or <code>yarn global remove</code>" %}
+
+The command has the following synax:
+
+```
+Uninstalls a tool from your toolchain
+
+USAGE:
+    volta uninstall [FLAGS] <tool>
+
+FLAGS:
+        --verbose    Enables verbose diagnostics
+        --quiet      Prevents unnecessary output
+    -h, --help       Prints help information
+
+ARGS:
+    <tool>    The tool to uninstall, e.g. `node`, `npm`, `yarn`, or <package>
+```

--- a/subdomains/docs/_reference/which.md
+++ b/subdomains/docs/_reference/which.md
@@ -1,0 +1,22 @@
+---
+title: volta which
+---
+
+# `volta which`
+
+The `volta which` command will unwrap Volta's shims and locate the actual binary that will be launched by Volta. It has the following synax:
+
+```
+Locates the actual binary that will be called by Volta
+
+USAGE:
+    volta which [FLAGS] <binary>
+
+FLAGS:
+        --verbose    Enables verbose diagnostics
+        --quiet      Prevents unnecessary output
+    -h, --help       Prints help information
+
+ARGS:
+    <binary>    The binary to find, e.g. `node` or `npm`
+```


### PR DESCRIPTION
Noted in a comment (https://github.com/volta-cli/volta/issues/531#issuecomment-671045651), our "Reference" section is out-of-date and doesn't show a reference for all commands.

Updated to include all of the commands that are shown when you run `volta --help` and re-ordered to match the order of commands listed there.