### PR TITLE
Change contributing documentation to reflect that Volta uses the late…

### DIFF
--- a/subdomains/docs/_contributing/index.md
+++ b/subdomains/docs/_contributing/index.md
@@ -22,7 +22,7 @@ Contribution to Volta is organized under the terms of the [Contributor Covenant 
 
 ### Rust
 
-Volta is intended to compile with [Rust 1.41](https://www.rust-lang.org/) or newer.
+Volta is intended to compile with the latest [stable Rust release](https://www.rust-lang.org/).
 
 ### Building
 


### PR DESCRIPTION
Info
-----
* In https://github.com/volta-cli/volta/pull/868, we are using the `matches!` macro, which was introduced in Rust 1.42
* The docs currently indicate that Volta is intended to compile on Rust 1.41 or newer, so we would need to bump that number.
* Since Volta is a binary project and not a library, there isn't any external reason why would need to support building against an older Rust version.
* In our CI, we are currently using the latest stable for each build.

Changes
-----
* Updated the documentation to reflect that Volta is intended to be compiled with the latest stable Rust release.