### PR TITLE
Explain what Volta is on the homepage

### DIFF
--- a/subdomains/www/index.md
+++ b/subdomains/www/index.md
@@ -1,6 +1,6 @@
 ---
 layout: home
-tagline: Start your engines.
+tagline: A hassle-free tool to manage your JavaScript command-line tools. Start your engines.
 start: https://docs.volta.sh/guide/getting-started/
 features:
   - title: ⚡ Fast


### PR DESCRIPTION
The [docs explain](https://docs.volta.sh/guide/) what Volta does quite well. I thought it might be nice to put that on the homepage of the website because it took me a while to understand when I first came across it.

For example, Rust explains what it is in the tagline of its website: https://www.rust-lang.org/