### PR TITLE
Editor's notes about the project rename

### DIFF
--- a/subdomains/blog/_posts/2018-08-20-state-of-the-notion.md
+++ b/subdomains/blog/_posts/2018-08-20-state-of-the-notion.md
@@ -5,6 +5,8 @@ date:   2018-08-20 10:32:05 -0700
 categories: update
 author: Dave Herman
 ---
+<span class="blog-notice">**NOTE: This post predates this project's [rename to Volta](https://blog.volta.sh/2019/05/13/hello-volta/).**</span>
+
 _Notion is a **JavaScript toolchain manager**, making sure you always get the right version of Node, package managers like npm and Yarn, and JS command-line tools. Best of all, Notion makes tool requirements **declarative and reproducible** by using_ `package.json` _to remember and launch the right versions of a project’s required tools, so developers and users always see their projects build and run in a consistent environment._
 
 # Minimum viable status update

--- a/subdomains/blog/_posts/2019-02-05-state-of-the-notion.md
+++ b/subdomains/blog/_posts/2019-02-05-state-of-the-notion.md
@@ -5,6 +5,8 @@ date:   2019-02-05 10:07:41 -0700
 categories: update
 author: Dave Herman
 ---
+<span class="blog-notice">**NOTE: This post predates this project's [rename to Volta](https://blog.volta.sh/2019/05/13/hello-volta/).**</span>
+
 _Notion is a **JavaScript toolchain manager**, making sure you always get the right version of Node, package managers like npm and Yarn, and JS command-line tools. Best of all, Notion makes tool requirements **declarative and reproducible** by using_ `package.json` _to remember and launch the right versions of a project’s required tools, so developers and users always see their projects build and run in a consistent environment._
 
 # What's new?

--- a/subdomains/blog/_posts/2019-05-13-hello-volta.md
+++ b/subdomains/blog/_posts/2019-05-13-hello-volta.md
@@ -15,11 +15,11 @@ Volta 0.5.0 is out, with lots of new features and improvements, including:
 - Safe, fast management of npm-distributed binaries!
 - Idiomatic version syntax (e.g. `typescript@3.4`)
 
-**Compatibility note for Notion users:** The `package.json` key for pinned tools is now called `"volta"`. You'll need to rename the `"toolchain"` key to `"volta"` in any existing pinned projects.
+**Compatibility note for current users:** The `package.json` key for pinned tools is now called `"volta"`. You'll need to rename the `"toolchain"` key to `"volta"` in any existing pinned projects.
 
-About the name: Notion started as a Node version manager (hence the “No—” alliteration). Since then, two things happened: first, a number of people brought to our attention the Notion productivity tool, and we decided the polite thing to do would be to rename. Second, since the project has grown in scope to let you [manage arbitrary JavaScript tools](https://docs.volta.sh/guide/understanding#installing-package-binaries), we figured it was a good opportunity to rethink the name anyway!
+About the name: This project started as a Node version manager (hence the “No—” alliteration in the old name Notion). Since then, two things happened: first, a number of people brought to our attention the Notion productivity tool, and we decided the polite thing to do would be to rename. Second, since the project has grown in scope to let you [manage arbitrary JavaScript tools](https://docs.volta.sh/guide/understanding#installing-package-binaries), we figured it was a good opportunity to rethink the name anyway!
 
-For these reasons and after internal discussion, we decided on a new name. Notion is now Volta: The JavaScript Launcher ⚡! Our new website is up at [https://volta.sh/](https://volta.sh/).
+For these reasons and after internal discussion, we decided on a new name. What we once called Notion is now Volta: The JavaScript Launcher ⚡! Our new website is up at [https://volta.sh/](https://volta.sh/).
 
 Download Volta 0.5.0 and let us know what you think!
 

--- a/theme/_sass/volta/_layout.scss
+++ b/theme/_sass/volta/_layout.scss
@@ -471,6 +471,12 @@ footer {
   }
 }
 
+span.blog-notice {
+    background-color: #fcd;
+    padding: 5px;
+    border-radius: 2px;
+}
+
 h1.blog-title {
     font-family: $homepage-font;
 }


### PR DESCRIPTION
This PR adds notices to old blog posts clearing up any potential confusion about the 2019 rename (Notion -> Volta), following a discussion in volta-cli/volta#1013.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/307871/132939533-13a8f27a-1ed2-432d-87b5-4105ca39667d.png">
