### PR TITLE
docs(guide): emphasize the install command is for setting a default version

### DIFF
--- a/subdomains/docs/_guide/understanding.md
+++ b/subdomains/docs/_guide/understanding.md
@@ -13,9 +13,9 @@ Similar to package managers, Volta keeps track of which project (if any) you're 
 You control the tools managed by your Volta toolchain with two commands: `volta install` and `volta uninstall`.
 
 ### Installing Node engines
-Every time you install a tool to your toolchain, you set the default version of that tool, which Volta will use unless you're working within a project directory that has configured Volta to use a different version.
+To install a tool to your toolchain, you set the _default version_ of that tool. Volta will always use this default, unless you're working within a project directory that has configured Volta to use a different version. When you choose a default version, Volta will also download that version to the local cache.
 
-For example, you can select your default version of `node` by installing a particular version:
+For example, you can select an exact version of `node` to be your default version:
 
 ```sh
 volta install node@{{ site.data.versions.node.stable.full }}

--- a/subdomains/docs/_guide/understanding.md
+++ b/subdomains/docs/_guide/understanding.md
@@ -13,8 +13,7 @@ Similar to package managers, Volta keeps track of which project (if any) you're 
 You control the tools managed by your Volta toolchain with two commands: `volta install` and `volta uninstall`.
 
 ### Installing Node engines
-
-When you install a tool to your toolchain, you always choose a _default version_ of that tool, which Volta will use unless you're working within a project directory that has configured Volta to use a different version. Alternatively, you can use `volta fetch` to install a tool locally without changing the _default version_.
+Every time you install a tool to your toolchain, you set the default version of that tool, which Volta will use unless you're working within a project directory that has configured Volta to use a different version.
 
 For example, you can select your default version of `node` by installing a particular version:
 

--- a/subdomains/docs/_guide/understanding.md
+++ b/subdomains/docs/_guide/understanding.md
@@ -14,7 +14,7 @@ You control the tools managed by your Volta toolchain with two commands: `volta 
 
 ### Installing Node engines
 
-When you install a tool to your toolchain, you always choose a _default version_ of that tool, which Volta will use unless you're working within a project directory that has configured Volta to use a different version.
+When you install a tool to your toolchain, you always choose a _default version_ of that tool, which Volta will use unless you're working within a project directory that has configured Volta to use a different version. Alternatively, you can use `volta fetch` to install a tool locally without changing the _default version_.
 
 For example, you can select your default version of `node` by installing a particular version:
 


### PR DESCRIPTION
- Mention the option to use `volta fetch` to not change the default version. The verbosity will drive home that `volta install` will change your default _every_ time it is run.