### PR TITLE
Mention 'macOS' in Unix section of 'Getting Started'

### DIFF
--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -6,7 +6,7 @@ title: Getting Started
 
 ## Unix Installation
 
-On most Unix systems, you can install Volta with a single command:
+On most Unix systems including macOS, you can install Volta with a single command:
 
 ```bash
 curl https://get.volta.sh | bash


### PR DESCRIPTION
Does it make sense to mention "macOS" in the Unix section? I feel like I typically expect guides to segment between Mac, Windows, and Linux, so I was expecting a Mac section as well.