### PR TITLE
Update 'Installing Old Versions' section with 1.1.0

### DIFF
--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -38,10 +38,10 @@ curl https://get.volta.sh | bash -s -- --skip-setup
 
 ## Installing Old Versions
 
-The default installer script provided by [get.volta.sh](https://get.volta.sh) only supports installing Volta 0.7.0 and above. If you wish to install an older version, you can install it using the following script (on Unix, replacing `0.6.8` with the version you want to install):
+The default installer script provided by [get.volta.sh](https://get.volta.sh) only supports installing Volta 1.1.0 and above. If you wish to install an older version, you can install it using the following script on Unix, replacing `1.0.8` with the version you want to install:
 
 ```
-curl https://raw.githubusercontent.com/volta-cli/volta/e0290c2d7b0e80bf64e7c5d403789bc51678d16c/dev/unix/volta-install.sh | bash -s -- --version 0.6.8
+curl https://raw.githubusercontent.com/volta-cli/volta/8f2074f423c65405dfba9858d9bcf393c38ffb45/dev/unix/volta-install.sh | bash -s -- --version 1.0.8
 ```
 
 For Windows, you can download and install the Installer `.msi` file for the specific version that you want to install.


### PR DESCRIPTION
Info
-----
* With the release of Volta 1.1.0, the get.volta.sh installer only works for that version, due to the change in release artifacts.
* We have a section in our docs about installing old versions, from the last time we had a breaking change in the install script (Volta 0.7.0).
* However, Volta 0.7.0 is 2.5 years old now (Volta 1.0.0 itself is almost 2 years old!) and far from supported.
* Rather than adding an extra section and trying to explain to use script A for Volta < 0.7.0 and script B for Volta between 0.7.0 and 1.1.0, we can likely drop the reference to the 0.6.8 installer entirely.

Changes
-----
* Updated the minimum supported Volta version for the default installer in the `Installing Old Versions`
* Update the code sample to use the appropriate 1.0 installer and example version