### PR TITLE
docs: improve usage instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To test one of the subdomains, run a Jekyll server from its subdirectory. For ex
 
 ```sh
 cd subdomains/www
+bundle install
 bundle exec jekyll serve
 ```
 


### PR DESCRIPTION
Current instructions result in error

```shell
~code/volta-website main
null.local ᐳ cd subdomains/www

~code/volta-website/subdomains/www main
null.local ᐳ bundle exec jekyll serve
bundler: command not found: jekyll
Install missing gem executables with `bundle install`
```