### PR TITLE
Add more information to manual installation instructions

### DIFF
--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -38,6 +38,10 @@ Follow the instructions in [getting started](/guide/getting-started) to manually
 
 {% include note.html content="We don't currently support skipping <code>volta setup</code> on Windows." %}
 
+## Github CI
+
+Volta distrubites a custom [Github action](https://github.com/volta-cli/action) that will automatically download Volta, cache it, and download the pinned versions of your tools in the project's `package.json`.
+
 ## Installing Old Versions
 
 The default installer script provided by [get.volta.sh](https://get.volta.sh) only supports installing Volta 1.1.0 and above. If you wish to install an older version, you can install it using the following script on Unix, replacing `1.0.8` with the version you want to install:
@@ -76,7 +80,3 @@ Updating the PATH can be managed manually, if desired, or you can call `volta se
 ### Custom Volta Home (Optional)
 
 If you wish to use a different directory for the Volta data than the default `VOLTA_HOME` listed in the previous section, you need to set the environment variable `VOLTA_HOME` to that directory. If that is set, then `volta setup` will still work correctly for a custom data directory.
-
-## Github CI
-
-Volta distrubites a custom [Github action](https://github.com/volta-cli/action) that will automatically download Volta, cache it, and download the pinned versions of your tools in the project's `package.json`.

--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -34,6 +34,8 @@ If you wish to run the installer but do not want your profile scripts modified b
 curl https://get.volta.sh | bash -s -- --skip-setup
 ```
 
+Follow the instructions in [getting started](/guide/getting-started) to manually finish setting up Volta.
+
 {% include note.html content="We don't currently support skipping <code>volta setup</code> on Windows." %}
 
 ## Installing Old Versions

--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -34,8 +34,6 @@ If you wish to run the installer but do not want your profile scripts modified b
 curl https://get.volta.sh | bash -s -- --skip-setup
 ```
 
-Follow the instructions in [getting started](/guide/getting-started) to manually finish setting up Volta.
-
 {% include note.html content="We don't currently support skipping <code>volta setup</code> on Windows." %}
 
 ## Github CI

--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -40,7 +40,7 @@ Follow the instructions in [getting started](/guide/getting-started) to manually
 
 ## Github CI
 
-Volta distrubites a custom [Github action](https://github.com/volta-cli/action) that will automatically download Volta, cache it, and download the pinned versions of your tools in the project's `package.json`.
+For convenience, we provide a custom [Github action](https://github.com/volta-cli/action) which will automatically download Volta, cache it, and download the pinned versions of your tools in the project's `package.json`.
 
 ## Installing Old Versions
 

--- a/subdomains/docs/_advanced/installers.md
+++ b/subdomains/docs/_advanced/installers.md
@@ -76,3 +76,7 @@ Updating the PATH can be managed manually, if desired, or you can call `volta se
 ### Custom Volta Home (Optional)
 
 If you wish to use a different directory for the Volta data than the default `VOLTA_HOME` listed in the previous section, you need to set the environment variable `VOLTA_HOME` to that directory. If that is set, then `volta setup` will still work correctly for a custom data directory.
+
+## Github CI
+
+Volta distrubites a custom [Github action](https://github.com/volta-cli/action) that will automatically download Volta, cache it, and download the pinned versions of your tools in the project's `package.json`.

--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -16,6 +16,12 @@ For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and
 - Set the `VOLTA_HOME` variable to `$HOME/.volta`
 - Add `$VOLTA_HOME/bin` to the beginning of your `PATH` variable
 
+You need set your default version of node before running any of Volta's commands, to use the LTS version of node run:
+
+```bash
+volta install node
+```
+
 ## Windows Installation
 
 For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-windows-x86_64.msi) and follow the instructions.

--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -18,12 +18,6 @@ For [bash](https://www.gnu.org/software/bash/), [zsh](https://www.zsh.org/), and
 - Set the `VOLTA_HOME` variable to `$HOME/.volta`
 - Add `$VOLTA_HOME/bin` to the beginning of your `PATH` variable
 
-You need set your default version of node before running any of Volta's commands, to use the LTS version of node run:
-
-```bash
-volta install node
-```
-
 ### Windows Installation
 
 For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-windows-x86_64.msi) and follow the instructions.

--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -4,7 +4,9 @@ title: Getting Started
 
 # Getting Started
 
-## Unix Installation
+## Install Volta
+
+### Unix Installation
 
 On most Unix systems including macOS, you can install Volta with a single command:
 
@@ -22,7 +24,7 @@ You need set your default version of node before running any of Volta's commands
 volta install node
 ```
 
-## Windows Installation
+### Windows Installation
 
 For Windows, [download and run the Windows installer](https://github.com/volta-cli/volta/releases/download/v{{ site.data.latest-version }}/volta-{{ site.data.latest-version }}-windows-x86_64.msi) and follow the instructions.
 
@@ -32,6 +34,23 @@ For Windows, [download and run the Windows installer](https://github.com/volta-c
     <li>Run Volta with elevated privileges (not recommended)</li>
 </ul>" %}
 
-### Windows Subsystem for Linux
+#### Windows Subsystem for Linux
 
 If you are using Volta within the Windows Subsystem for Linux, follow the Unix installation guide above.
+
+
+## Select a default Node version
+
+This is the version that Volta will use everywhere outside of projects that have a pinned version. The `volta pin node` command will use this version by default.
+
+To select a specific version of Node, run:
+
+```bash
+volta install node@{{ site.data.versions.node.stable.full }}
+```
+
+Or to use the latest LTS version, run:
+
+```bash
+volta install node
+```

--- a/subdomains/docs/_guide/getting-started.md
+++ b/subdomains/docs/_guide/getting-started.md
@@ -35,7 +35,7 @@ If you are using Volta within the Windows Subsystem for Linux, follow the Unix i
 
 ## Select a default Node version
 
-This is the version that Volta will use everywhere outside of projects that have a pinned version. The `volta pin node` command will use this version by default.
+This is the version that Volta will use everywhere outside of projects that have a pinned version.
 
 To select a specific version of Node, run:
 


### PR DESCRIPTION
This PR aims to expand the documentation about manual installation and CI usage. As discussed in https://github.com/volta-cli/volta/issues/1389 some users may find it difficult to catch the fact volta requires `install` to be ran at least once before running any other tooling and a few users had no idea bout the provided Github action that solves the deterministic behaviour.