### PR TITLE
Add `.zshenv` to uninstall instructions

### DIFF
--- a/subdomains/docs/_advanced/uninstall.md
+++ b/subdomains/docs/_advanced/uninstall.md
@@ -20,8 +20,9 @@ rm -rf ~/.volta
     1. `.bashrc`
     2. `.bash_profile`
     3. `.zshrc`
-    4. `config.fish`
-    5. `.profile`
+    4. `.zshenv`
+    5. `config.fish`
+    6. `.profile`
 
 {% include note.html content="You may need to open a new terminal after making this change, as many shells cache the location of recent commands" %}
 


### PR DESCRIPTION
Hi,

Nice tool, thanks for creating this ! (Well, just starting to try it but so far looks very good to me :D)

It seems that `~/.zshenv` is one of the files modified by the install process (both noticed on my machine, and I can find refererences to it in the code), so, this PR updates the uninstall docs to reflect that fact.